### PR TITLE
chore: use github.token bot flow for upgrade PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,9 @@ description: "P6 GHA: Upgrade Dependencies for a CDK App"
 author: "Philip M. Gollucci"
 inputs:
   gh_token:
-    description: "GitHub Token"
-    required: true
+    description: "Fallback GitHub token (e.g., P6_A_GH_TOKEN)"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -26,7 +27,8 @@ runs:
       id: token
       uses: p6m7g8-actions/gh-token-normalize@main
       with:
-        preferred-token: ${{ inputs.gh_token }}
+        preferred-token: ${{ github.token }}
+        fallback-token: ${{ inputs.gh_token }}
         default-token: ${{ github.token }}
     - name: Configure authenticated git remote
       shell: bash
@@ -37,12 +39,17 @@ runs:
       uses: peter-evans/create-pull-request@v8.1.0
       with:
         token: ${{ steps.token.outputs.value }}
+        branch-token: ${{ steps.token.outputs.value }}
         base: main
         commit-message: |
           chore(deps): upgrade dependencies
         branch: github-actions/upgrade-main
         title: "chore(deps): upgrade dependencies"
-        labels: auto-merge
+        labels: |
+          auto-approve
+          auto-merge
+        reviewers: |
+          p6m7g8-automation
         body: |
           Upgrades project dependencies.
         author: github-actions <github-actions@github.com>


### PR DESCRIPTION
## Summary
- prefer `github.token` for PR creation so actor is github-actions[bot]
- keep `gh_token` (P6_A_GH_TOKEN) as fallback only
- request reviewer `p6m7g8-automation`
- label PRs with `auto-approve` and `auto-merge`

## Testing
- yamllint action.yml (existing warning baseline only)